### PR TITLE
Remove target-branch from dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
       day: "saturday"
       time: "09:00"
       timezone: "America/New_York"
-    target-branch: "feature/dependency-updates"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -30,7 +29,6 @@ updates:
       day: "saturday"
       time: "09:00"
       timezone: "America/New_York"
-    target-branch: "feature/dependency-updates"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -48,7 +46,6 @@ updates:
       day: "saturday"
       time: "09:00"
       timezone: "America/New_York"
-    target-branch: "feature/dependency-updates"
     commit-message:
       prefix: "deps"
       include: "scope"


### PR DESCRIPTION
Removed target-branch configuration from multiple schedules.